### PR TITLE
Recording more information in the ResourceEntry object and bugfix of ByteArrayDataReader.hasMore().

### DIFF
--- a/java/src/org/boris/pecoff4j/ResourceEntry.java
+++ b/java/src/org/boris/pecoff4j/ResourceEntry.java
@@ -12,8 +12,10 @@ package org.boris.pecoff4j;
 public class ResourceEntry {
 	private int id;
 	private String name;
+    private int offset;
 	private byte[] data;
 	private ResourceDirectory directory;
+    private int dataRVA;
 	private int codePage;
 	private int reserved;
 
@@ -33,6 +35,14 @@ public class ResourceEntry {
 		this.name = name;
 	}
 
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
 	public byte[] getData() {
 		return data;
 	}
@@ -48,6 +58,14 @@ public class ResourceEntry {
 	public void setDirectory(ResourceDirectory directory) {
 		this.directory = directory;
 	}
+
+    public int getDataRVA() {
+        return dataRVA;
+    }
+
+    public void setDataRVA(int dataRVA) {
+        this.dataRVA = dataRVA;
+    }
 
 	public int getCodePage() {
 		return codePage;

--- a/java/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
+++ b/java/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
@@ -47,7 +47,7 @@ public class ByteArrayDataReader implements IDataReader {
 	@Override
 	public boolean hasMore() throws IOException
 	{
-	    return offset + position < length;
+	    return position < length;
 	}
 
 	@Override

--- a/java/src/org/boris/pecoff4j/io/PEParser.java
+++ b/java/src/org/boris/pecoff4j/io/PEParser.java
@@ -693,6 +693,7 @@ public class PEParser {
 		ResourceEntry re = new ResourceEntry();
 		int id = dr.readDoubleWord();
 		int offset = dr.readDoubleWord();
+        re.setOffset(offset);
 		int pos = dr.getPosition();
 		if ((id & 0x80000000) != 0) {
 			dr.jumpTo(id & 0x7fffffff);
@@ -709,6 +710,7 @@ public class PEParser {
 			int size = dr.readDoubleWord();
 			int cp = dr.readDoubleWord();
 			int res = dr.readDoubleWord();
+            re.setDataRVA(rva);
 			re.setCodePage(cp);
 			re.setReserved(res);
 			dr.jumpTo(rva - baseAddress);


### PR DESCRIPTION
Recording Data RVA and offset information in the ResourceEntry object.

Fixed defect in ByteArrayDataReader.hasMore(). "position" is an index within the limit of "length". Consider for example this case: new ByteArrayDataReader(b, 900, 100) where b is of length 1000.