### PR TITLE
readUnicode reads a number of words equal to half the number of bytes

### DIFF
--- a/java/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
+++ b/java/src/org/boris/pecoff4j/io/ByteArrayDataReader.java
@@ -126,7 +126,7 @@ public class ByteArrayDataReader implements IDataReader {
 	@Override
 	public String readUnicode(int size) throws IOException {
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < size; i++) {
+		for (int i = 0; i < size / 2; i++) {
 			sb.append((char) readWord());
 		}
 		return sb.toString();

--- a/java/src/org/boris/pecoff4j/io/DataReader.java
+++ b/java/src/org/boris/pecoff4j/io/DataReader.java
@@ -142,7 +142,7 @@ public class DataReader implements IDataReader {
 	@Override
 	public String readUnicode(int size) throws IOException {
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < size; i++) {
+		for (int i = 0; i < size / 2; i++) {
 			sb.append((char) readWord());
 		}
 		return sb.toString();


### PR DESCRIPTION
Seems pretty straightforward. A Java word is 2 bytes. The StringTable structure lengths give you numbers of bytes, not numbers of words.