### PR TITLE
Correcting StringFileInfo parsing, considering String wType

### DIFF
--- a/java/src/org/boris/pecoff4j/io/ResourceParser.java
+++ b/java/src/org/boris/pecoff4j/io/ResourceParser.java
@@ -220,18 +220,27 @@ public class ResourceParser {
 	}
 
 	public static StringPair readStringPair(IDataReader dr) throws IOException {
-		StringPair sp = new StringPair();
-		sp.setLength(dr.readWord());
-		sp.setValueLength(dr.readWord());
-		sp.setType(dr.readWord());
-		sp.setKey(dr.readUnicode());
-		sp.setPadding(alignDataReader(dr));
-		int valueLength = sp.getValueLength();
-		if (sp.getType() == 0) // 0 = binary, 1 = text, other = invalid
-			valueLength /= 2;
-		sp.setValue(dr.readUnicode(valueLength).trim());
-		alignDataReader(dr);
-		return sp;
+        int initialPos = dr.getPosition();
+
+        StringPair sp = new StringPair();
+        sp.setLength(dr.readWord());
+        sp.setValueLength(dr.readWord());
+        sp.setType(dr.readWord());
+        sp.setKey(dr.readUnicode());
+        sp.setPadding(alignDataReader(dr));
+
+        int remainingWords = (sp.getLength() - (dr.getPosition() - initialPos)) / 2;
+        int valueLength = sp.getValueLength();
+        if (sp.getType() == 0) // wType == 0 => binary; wLength is in bytes
+            valueLength /= 2;
+        if (valueLength > remainingWords)
+            valueLength = remainingWords;
+        sp.setValue(dr.readUnicode(valueLength).trim());
+
+        int remainingBytes = (sp.getLength() - (dr.getPosition() - initialPos));
+        dr.skipBytes(remainingBytes);
+        alignDataReader(dr);
+        return sp;
 	}
 
 	public static Manifest readManifest(IDataReader dr, int length)

--- a/java/src/org/boris/pecoff4j/io/ResourceParser.java
+++ b/java/src/org/boris/pecoff4j/io/ResourceParser.java
@@ -226,7 +226,10 @@ public class ResourceParser {
 		sp.setType(dr.readWord());
 		sp.setKey(dr.readUnicode());
 		sp.setPadding(alignDataReader(dr));
-		sp.setValue(dr.readUnicode(sp.getValueLength()).trim());
+		int valueLength = sp.getValueLength();
+		if (sp.getType() == 0) // 0 = binary, 1 = text, other = invalid
+			valueLength /= 2;
+		sp.setValue(dr.readUnicode(valueLength).trim());
 		alignDataReader(dr);
 		return sp;
 	}

--- a/java/src/org/boris/pecoff4j/io/ResourceParser.java
+++ b/java/src/org/boris/pecoff4j/io/ResourceParser.java
@@ -220,27 +220,27 @@ public class ResourceParser {
 	}
 
 	public static StringPair readStringPair(IDataReader dr) throws IOException {
-        int initialPos = dr.getPosition();
+		int initialPos = dr.getPosition();
 
-        StringPair sp = new StringPair();
-        sp.setLength(dr.readWord());
-        sp.setValueLength(dr.readWord());
-        sp.setType(dr.readWord());
-        sp.setKey(dr.readUnicode());
-        sp.setPadding(alignDataReader(dr));
+		StringPair sp = new StringPair();
+		sp.setLength(dr.readWord());
+		sp.setValueLength(dr.readWord());
+		sp.setType(dr.readWord());
+		sp.setKey(dr.readUnicode());
+		sp.setPadding(alignDataReader(dr));
 
-        int remainingWords = (sp.getLength() - (dr.getPosition() - initialPos)) / 2;
-        int valueLength = sp.getValueLength();
-        if (sp.getType() == 0) // wType == 0 => binary; wLength is in bytes
-            valueLength /= 2;
-        if (valueLength > remainingWords)
-            valueLength = remainingWords;
-        sp.setValue(dr.readUnicode(valueLength).trim());
+		int remainingWords = (sp.getLength() - (dr.getPosition() - initialPos)) / 2;
+		int valueLength = sp.getValueLength();
+		if (sp.getType() == 0) // wType == 0 => binary; wLength is in bytes
+			valueLength /= 2;
+		if (valueLength > remainingWords)
+			valueLength = remainingWords;
+		sp.setValue(dr.readUnicode(valueLength).trim());
 
-        int remainingBytes = (sp.getLength() - (dr.getPosition() - initialPos));
-        dr.skipBytes(remainingBytes);
-        alignDataReader(dr);
-        return sp;
+		int remainingBytes = (sp.getLength() - (dr.getPosition() - initialPos));
+		dr.skipBytes(remainingBytes);
+		alignDataReader(dr);
+		return sp;
 	}
 
 	public static Manifest readManifest(IDataReader dr, int length)


### PR DESCRIPTION
The library was assuming that the wValueLength of a String in a StringTable is always a number of characters/words (which is true when wType == 1 (text)), but when wType == 0 (binary), the wValueLength's unit is a number of bytes. wLength is always bytes.

I think we can assume a StringFileInfo table's String values are always UTF-16 encoded even if they're not wType 1, so this means we must simply read half that number and parse them as normal. I have tried this on a few executable files in my possession and found it to fix the ones that weren't being parsed correctly. (The only one still failing has a bad resource directory, unrelated to this.)

This patch also adds some bounds checking for an incorrect wValueLength (as in one of my test files). We only read up to the end of the wLength at maximum (in case it's too high), then skip any leftover bytes (in case it's too low).