### PR TITLE
Solved the problem of can't analysis a series file

### DIFF
--- a/java/src/org/boris/pecoff4j/io/PEParser.java
+++ b/java/src/org/boris/pecoff4j/io/PEParser.java
@@ -753,6 +753,17 @@ public class PEParser {
 		dd.setLength(dr.readDoubleWord());
 		dd.setRevision(dr.readWord());
 		dd.setCertificateType(dr.readWord());
+
+		if(dd.getLength() >= 65534 || dd.getLength() <= 8)
+		{
+			//System.out.println("dd.getLength() : " + dd.getLength());
+			byte[]certificate = new byte[16];
+			certificate[0] = 'e';certificate[1] = 'r';certificate[2] = 'r';certificate[3] = 'o';certificate[4] = 'r';
+			dd.setCertificate(certificate);
+			return dd;
+		}
+		
+		//System.out.println("dd.getLength() : " + dd.getLength());
 		byte[] certificate = new byte[dd.getLength() - 8];
 		dr.read(certificate);
 		dd.setCertificate(certificate);


### PR DESCRIPTION
When someone put a series flie path into a ArrayList , and then analysis those files with the code " PEParser.parse(arrayList.get(i))" in a for-loop , there will be some error  sometime . This is because a code " dd.getLength() " is much biger then what the byte[]("byte[] certificate = new byte[dd.getLength() - 8];")  should be . And in this kind of situation，we can't catch the exception.