### PR TITLE
Fixing ArrayIndexOutofBounds when rva is less than baseAddress

### DIFF
--- a/java/src/org/boris/pecoff4j/io/PEParser.java
+++ b/java/src/org/boris/pecoff4j/io/PEParser.java
@@ -712,6 +712,7 @@ public class PEParser {
 			re.setDirectory(readResourceDirectory(dr, baseAddress));
 		} else {
 			dr.jumpTo(offset);
+			if(dr.getPosition() < 0) return null;
 			int rva = dr.readDoubleWord();
 			int size = dr.readDoubleWord();
 			int cp = dr.readDoubleWord();
@@ -720,6 +721,7 @@ public class PEParser {
 			re.setCodePage(cp);
 			re.setReserved(res);
 			dr.jumpTo(rva - baseAddress);
+			if(dr.getPosition() < 0) return null;
 			byte[] b = new byte[size];
 			dr.read(b);
 			re.setData(b);


### PR DESCRIPTION
this fix exists in jonnyzzz fork - only porting as I am running into the issue. 

https://github.com/jonnyzzz/PE/blob/master/src/org/boris/pecoff4j/io/PEParser.java 