### PR TITLE
Fix UTF-16 size calculation

### DIFF
--- a/src/main/java/com/kichik/pecoff4j/util/Strings.java
+++ b/src/main/java/com/kichik/pecoff4j/util/Strings.java
@@ -1,15 +1,9 @@
 package com.kichik.pecoff4j.util;
 
-import java.io.UnsupportedEncodingException;
-
 public class Strings {
 
 	public static int getUtf16Length(String string) {
-		try {
-			return string.getBytes("UTF-16").length + 2; // null terminator
-		} catch (UnsupportedEncodingException e) {
-			return string.length() * 2 + 2;
-		}
+		return string.length() * 2 + 2; // null terminator
 	}
 
 }

--- a/src/test/java/com/kichik/pecoff4j/StringsTest.java
+++ b/src/test/java/com/kichik/pecoff4j/StringsTest.java
@@ -1,0 +1,15 @@
+package com.kichik.pecoff4j;
+
+import com.kichik.pecoff4j.util.Strings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StringsTest {
+    @Test
+    public void testUtf16Length() {
+        assertEquals(2, Strings.getUtf16Length(""));
+        assertEquals(4, Strings.getUtf16Length("π"));
+        assertEquals(10, Strings.getUtf16Length("test"));
+    }
+}


### PR DESCRIPTION
The original implementation is not working for me as `string.getBytes("UTF-16")` returns a string starting with a byte order mark (BOM), so there are 2 extra bytes.