### PR TITLE
Improve VarFileInfo parsing support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>enforce-jdk-paths</id>

--- a/src/main/java/com/kichik/pecoff4j/resources/Var.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/Var.java
@@ -1,0 +1,57 @@
+package com.kichik.pecoff4j.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A list of language and code page identifier pairs.
+ *
+ * See <a href="https://learn.microsoft.com/en-us/windows/win32/menurc/var-str">Var structure</a> for details.
+ */
+public class Var {
+	private int length;
+	private int valueLength;
+	private int type;
+	private String key;
+	private final List<Integer> values = new ArrayList<>();
+
+	public int getLength() {
+		return length;
+	}
+
+	public void setLength(int length) {
+		this.length = length;
+	}
+
+	public int getValueLength() {
+		return valueLength;
+	}
+
+	public void setValueLength(int valueLength) {
+		this.valueLength = valueLength;
+	}
+
+	public int getType() {
+		return type;
+	}
+
+	public void setType(int type) {
+		this.type = type;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public List<Integer> getValues() {
+		return values;
+	}
+
+	public void addValue(int value) {
+		values.add(value);
+	}
+}

--- a/src/main/java/com/kichik/pecoff4j/resources/VarFileInfo.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/VarFileInfo.java
@@ -13,9 +13,35 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VarFileInfo {
+	private int length;
+	private int valueLength;
+	private int type;
 	private String key;
-	private List<String> names = new ArrayList();
-	private List<String> values = new ArrayList();
+	private final List<Var> vars = new ArrayList<>();
+
+	public void setLength(int length) {
+		this.length = length;
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	public void setValueLength(int valueLength) {
+		this.valueLength = valueLength;
+	}
+
+	public int getValueLength() {
+		return valueLength;
+	}
+
+	public void setType(int type) {
+		this.type = type;
+	}
+
+	public int getType() {
+		return type;
+	}
 
 	public String getKey() {
 		return key;
@@ -25,25 +51,12 @@ public class VarFileInfo {
 		this.key = key;
 	}
 
-	public int size() {
-		return names.size();
+	public void addVar(Var v) {
+		vars.add(v);
 	}
 
-	public String getName(int index) {
-		return names.get(index);
+	public List<Var> getVars() {
+		return vars;
 	}
 
-	public String getValue(int index) {
-		return values.get(index);
-	}
-
-	public void add(String name, String value) {
-		names.add(name);
-		values.add(value);
-	}
-
-	public void clear() {
-		names.clear();
-		values.clear();
-	}
 }


### PR DESCRIPTION
It seems that until now, the VarFileInfo has not been parsed most of the time "thanks" to the break statement in ResourceParser#readVersionInfo: Once the StringFileInfo structure is read, the rest is just skipped. That would also explain why nobody noticed that VarFileInfo did not match [the official spec](https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo) 