### PR TITLE
Add write support for GroupIconDirectory and its entries

### DIFF
--- a/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectory.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectory.java
@@ -10,6 +10,8 @@
 package com.kichik.pecoff4j.resources;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.kichik.pecoff4j.io.DataReader;
 import com.kichik.pecoff4j.io.IDataReader;
@@ -19,23 +21,34 @@ import com.kichik.pecoff4j.util.Reflection;
 public class GroupIconDirectory {
 	private int reserved;
 	private int type;
-	private int count;
-	private GroupIconDirectoryEntry[] entries;
+	private List<GroupIconDirectoryEntry> entries = new ArrayList<>();
 
 	public int getReserved() {
 		return reserved;
+	}
+
+	public void setReserved(int reserved) {
+		this.reserved = reserved;
 	}
 
 	public int getType() {
 		return type;
 	}
 
+	public void setType(int type) {
+		this.type = type;
+	}
+
 	public int getCount() {
-		return count;
+		return entries.size();
 	}
 
 	public GroupIconDirectoryEntry getEntry(int index) {
-		return entries[index];
+		return entries.get(index);
+	}
+
+	public List<GroupIconDirectoryEntry> getEntries() {
+		return entries;
 	}
 
 	@Override
@@ -51,10 +64,9 @@ public class GroupIconDirectory {
 		GroupIconDirectory gi = new GroupIconDirectory();
 		gi.reserved = dr.readWord();
 		gi.type = dr.readWord();
-		gi.count = dr.readWord();
-		gi.entries = new GroupIconDirectoryEntry[gi.count];
-		for (int i = 0; i < gi.count; i++) {
-			gi.entries[i] = GroupIconDirectoryEntry.read(dr);
+		int count = dr.readWord();
+		for (int i = 0; i < count; i++) {
+			gi.entries.add(GroupIconDirectoryEntry.read(dr));
 		}
 
 		return gi;
@@ -63,9 +75,9 @@ public class GroupIconDirectory {
 	public void write(IDataWriter dw) throws IOException {
 		dw.writeWord(reserved);
 		dw.writeWord(type);
-		dw.writeWord(count);
-		for (int i = 0; i < count; i++) {
-			entries[i].write(dw);
+		dw.writeWord(entries.size());
+		for (GroupIconDirectoryEntry entry : entries) {
+			entry.write(dw);
 		}
 	}
 }

--- a/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectory.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectory.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import com.kichik.pecoff4j.io.DataReader;
 import com.kichik.pecoff4j.io.IDataReader;
+import com.kichik.pecoff4j.io.IDataWriter;
 import com.kichik.pecoff4j.util.Reflection;
 
 public class GroupIconDirectory {
@@ -57,5 +58,14 @@ public class GroupIconDirectory {
 		}
 
 		return gi;
+	}
+
+	public void write(IDataWriter dw) throws IOException {
+		dw.writeWord(reserved);
+		dw.writeWord(type);
+		dw.writeWord(count);
+		for (int i = 0; i < count; i++) {
+			entries[i].write(dw);
+		}
 	}
 }

--- a/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectoryEntry.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectoryEntry.java
@@ -12,6 +12,7 @@ package com.kichik.pecoff4j.resources;
 import java.io.IOException;
 
 import com.kichik.pecoff4j.io.IDataReader;
+import com.kichik.pecoff4j.io.IDataWriter;
 import com.kichik.pecoff4j.util.Reflection;
 
 public class GroupIconDirectoryEntry {
@@ -78,5 +79,16 @@ public class GroupIconDirectoryEntry {
 
 	public void setId(int id) {
 		this.id = id;
+	}
+
+	public void write(IDataWriter dw) throws IOException {
+		dw.writeByte(width);
+		dw.writeByte(height);
+		dw.writeByte(colorCount);
+		dw.writeByte(reserved);
+		dw.writeWord(planes);
+		dw.writeWord(bitCount);
+		dw.writeDoubleWord(bytesInRes);
+		dw.writeWord(id);
 	}
 }

--- a/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectoryEntry.java
+++ b/src/main/java/com/kichik/pecoff4j/resources/GroupIconDirectoryEntry.java
@@ -49,28 +49,56 @@ public class GroupIconDirectoryEntry {
 		return width;
 	}
 
-	public int getHeight() {
+	public void setWidth(int width) {
+		this.width = width;
+	}
+
+	public int getHeight(){
 		return height;
+	}
+
+	public void setHeight(int height) {
+		this.height = height;
 	}
 
 	public int getColorCount() {
 		return colorCount;
 	}
 
+	public void setColorCount(int colorCount) {
+		this.colorCount = colorCount;
+	}
+
 	public int getReserved() {
 		return reserved;
+	}
+
+	public void setReserved(int reserved) {
+		this.reserved = reserved;
 	}
 
 	public int getPlanes() {
 		return planes;
 	}
 
+	public void setPlanes(int planes) {
+		this.planes = planes;
+	}
+
 	public int getBitCount() {
 		return bitCount;
 	}
 
+	public void setBitCount(int bitCount) {
+		this.bitCount = bitCount;
+	}
+
 	public int getBytesInRes() {
 		return bytesInRes;
+	}
+
+	public void setBytesInRes(int bytesInRes) {
+		this.bytesInRes = bytesInRes;
 	}
 
 	public int getId() {


### PR DESCRIPTION
Looks like the original author used two approaches for reading and writing: Separate utility classes (most of the time) and methods on the structure classes (seldomly). For an object oriented language like Java, I much prefer the second approach. It also keeps additional information like the field sizes and how the data is encoded in a single place. The same holds for the read and write method. Putting them in separate classes does not make it easier, IMO.

If you like this idea, I would move the read and write functionality to the corresponding classes where it makes sense. I would also add some unit tests to ensure that the write method generates the same bytes as the read method consumed. Otherwise, feel free to reject this PR. What do you think?